### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project is an **MCP (Model Context Protocol) server** that provides a set of tools to interact with the [AviationStack API](https://aviationstack.com/). It exposes endpoints for retrieving real-time and future flight data, aircraft types, and airplane details, making it easy to integrate aviation data into your applications.
 
+<a href="https://glama.ai/mcp/servers/@Pradumnasaraf/aviationstack-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Pradumnasaraf/aviationstack-mcp/badge" alt="Aviationstack Server MCP server" />
+</a>
+
 ### Demo
 
 https://github.com/user-attachments/assets/9325fcce-8ecc-4b01-8923-4ccb2f6968f4


### PR DESCRIPTION
This PR adds a badge for the [Aviationstack MCP Server](https://glama.ai/mcp/servers/@Pradumnasaraf/aviationstack-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Pradumnasaraf/aviationstack-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Pradumnasaraf/aviationstack-mcp/badge" alt="Aviationstack Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.