### PR TITLE
Fix uvx MCP dependency compatibility (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,51 +57,6 @@ All endpoints are implemented as MCP tools and are ready to be used in an MCP-co
 - All MCP tools are defined as Python functions decorated with `@mcp.tool()`.
 - The server uses the `FastMCP` class from `mcp.server.fastmcp`.
 
-### MCP Server configuration
-
-To add this server to your favorite MCP client, you can add the following to your MCP client configuration file.
-
-1. Using `uvx` without cloning the repository (recommended)
-
-```json
-{
-  "mcpServers": {
-    "Aviationstack MCP": {
-      "command": "uvx",
-      "args": [
-        "aviationstack-mcp"
-      ],
-      "env": {
-        "AVIATION_STACK_API_KEY": "<your-api-key>"
-      }
-    }
-  }
-}
-```
-
-2. By cloning the repository and running the server locally
-
-```json
-{
-  "mcpServers": {
-    "Aviationstack MCP": {
-      "command": "uv",
-      "args": [
-        "--directory",
-        "/path/to/aviationstack-mcp/src/aviationstack_mcp",
-        "run",
-        "-m",
-        "aviationstack_mcp",
-        "mcp",
-        "run"
-      ],
-      "env": {
-        "AVIATION_STACK_API_KEY": "<your-api-key>"
-      }
-    }
-  }
-}
-```
 ### MCP Server Configuration
 
 To add this server to your favorite MCP client, you can add the following to your MCP client configuration file.
@@ -154,6 +109,32 @@ For LangChain MCP clients using `MultiServerMCPClient`, the equivalent configura
 ```
 
 This configuration launches the AviationStack MCP server through `uvx` and keeps its MCP dependencies isolated from the application's Python environment.
+
+
+2. By cloning the repository and running the server locally
+
+```json
+{
+  "mcpServers": {
+    "Aviationstack MCP": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/path/to/aviationstack-mcp/src/aviationstack_mcp",
+        "run",
+        "-m",
+        "aviationstack_mcp",
+        "mcp",
+        "run"
+      ],
+      "env": {
+        "AVIATION_STACK_API_KEY": "<your-api-key>"
+      }
+    }
+  }
+}
+```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,58 @@ To add this server to your favorite MCP client, you can add the following to you
   }
 }
 ```
+### MCP Server Configuration
+
+To add this server to your favorite MCP client, you can add the following to your MCP client configuration file.
+
+#### 1. Using `uvx` without cloning the repository (recommended)
+
+The following configuration pins `aviationstack-mcp` to version `1.6.0` and uses `mcp==1.28.1` for compatibility with the server's `FastMCP` import path.
+
+```json
+{
+  "mcpServers": {
+    "Aviationstack MCP": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "aviationstack-mcp==1.6.0",
+        "--with",
+        "mcp==1.28.1",
+        "aviationstack-mcp"
+      ],
+      "env": {
+        "AVIATION_STACK_API_KEY": "<your-api-key>"
+      }
+    }
+  }
+}
+```
+
+> **Compatibility note:** If `uvx aviationstack-mcp` resolves an incompatible MCP SDK version in your environment, explicitly pinning `mcp==1.28.1` ensures compatibility with the server's `mcp.server.fastmcp` import.
+
+### Using with Python and `MultiServerMCPClient`
+
+For LangChain MCP clients using `MultiServerMCPClient`, the equivalent configuration is:
+
+```python
+"aviationstack": {
+    "transport": "stdio",
+    "command": "uvx",
+    "args": [
+        "--from",
+        "aviationstack-mcp==1.6.0",
+        "--with",
+        "mcp==1.28.1",
+        "aviationstack-mcp"
+    ],
+    "env": {
+        "AVIATION_STACK_API_KEY": AVIATION_STACK_API_KEY
+    }
+}
+```
+
+This configuration launches the AviationStack MCP server through `uvx` and keeps its MCP dependencies isolated from the application's Python environment.
 
 ## License
 


### PR DESCRIPTION
## Fixes Issue

Closes #15

Fixes the `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` error when running `aviationstack-mcp` with the latest `uv` dependency resolution.

## Changes proposed

* Updated the `uvx` MCP server configuration to pin `aviationstack-mcp` to `1.6.0`.
* Pinned `mcp` to `1.28.1` for compatibility with the server's `mcp.server.fastmcp` import.
* Updated the README MCP configuration with the working `uvx` setup.
* Verified that the MCP server starts successfully with:

  * `aviationstack-mcp==1.6.0`
  * `mcp==1.28.1`
* Verified the server successfully connects to `MultiServerMCPClient`.
* Verified that AviationStack MCP tools are discovered successfully alongside the Tavily MCP tools.

## Check List (Check all the applicable boxes)

* [x] My code follows the code style of this project.
* [x] This PR does not contain plagiarized content.
* [x] The title of my pull request is a short description of the requested changes.
* [x] I have updated the README.md file with the new features/tools information.

## Note to reviewers

The issue was caused by `uvx` resolving `mcp==2.0.0`, while `aviationstack-mcp` imports `FastMCP` using the `mcp.server.fastmcp` path.

Pinning `mcp==1.28.1` resolves the compatibility issue while keeping the recommended `uvx` installation method and avoiding changes to the user's local Python environment.

The fix was tested end-to-end using `MultiServerMCPClient`, and all AviationStack MCP tools were successfully discovered.

## Screenshots

No screenshots are necessary. The fix was verified through the MCP client tool discovery output.
