### PR TITLE
Pin mcp to v1 to fix broken Tests and Pylint workflows

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,8 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install requests
-        pip install mcp
+        pip install .
         pip install pylint
     - name: Analysing the code with pylint
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "mcp[cli]>=1.10.1",
+    "mcp[cli]>=1.10.1,<2",
     "requests",
     "pydantic>=2.0"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", extras = ["cli"], specifier = ">=1.10.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.10.1,<2" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "requests" },
 ]


### PR DESCRIPTION
## Problem

`main` has been failing CI since the last green push on 2026-07-15. Both the Tests and Pylint workflows fail with:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x,
where FastMCP was renamed to MCPServer
```

`pyproject.toml` declared `mcp[cli]>=1.10.1` with no upper bound, so `pip install .` began resolving to mcp 2.x once it was released. `server.py` imports `FastMCP` and uses `@mcp.tool`, `@mcp.prompt` and `@mcp.resource` in about 16 places, so it is v1 code throughout.

This also explains why Dependabot PRs #13 (cryptography) and #17 (pydantic) show red CI. They are unrelated to the failure and should go green once this lands.

## Changes

1. `pyproject.toml`: pin `mcp[cli]>=1.10.1,<2`.
2. `.github/workflows/pylint.yml`: replace `pip install requests` + `pip install mcp` with `pip install .`. The bare `pip install mcp` ignored the pinned spec, so the pin alone would not have fixed that job.

`uv.lock` already resolved mcp 1.28.1, so only the requirement metadata changed there.

## Verification

Reproduced the CI steps locally on this branch:

- `pip install .` resolves mcp 1.29.1
- `python -m unittest discover -s tests -v` passes, 6/6
- `pylint $(git ls-files '*.py')` rates 10.00/10

## Follow-up

Migrating to the mcp 2.x API (`MCPServer`) is the longer-term move, but it touches every tool, prompt and resource definition, so it belongs in its own PR.